### PR TITLE
Fix architecture test

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -35,7 +35,7 @@ ynh_script_progression --message="Validating installation parameters..."
 final_path=/var/www/$app
 test ! -e "$final_path" || ynh_die --message="This path already contains a folder"
 
-if dpkg-architecture --is armhf
+if dpkg-architecture --is armhf || dpkg-architecture --is arm64
 then
     ynh_die --message="Sorry, this app can not be installed on an ARM architecture"
 fi


### PR DESCRIPTION
## Problem
Don't allow installation if architecture is arm

## Solution
Test is architecture is armhf or arm64

## PR Status

Tested with the following code on odroid hc4

```
if dpkg-architecture --is armhf || dpkg-architecture --is arm64
then
echo arm
fi
```

- [X ] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
